### PR TITLE
Add brightness control keybindings in default config

### DIFF
--- a/etc/skel/.config/niri/cfg/keybinds.kdl
+++ b/etc/skel/.config/niri/cfg/keybinds.kdl
@@ -24,6 +24,10 @@ binds {
     XF86AudioMute                       allow-when-locked=true { spawn-sh "qs -c noctalia-shell ipc call volume muteOutput"; }
     XF86AudioMicMute                    allow-when-locked=true { spawn-sh "qs -c noctalia-shell ipc call volume muteInput"; }
 
+    // ─── Brightness Controls ───    
+    XF86MonBrightnessUp                 allow-when-locked=true { spawn-sh "qs -c noctalia-shell ipc call brightness increase"; }
+    XF86MonBrightnessDown               allow-when-locked=true { spawn-sh "qs -c noctalia-shell ipc call brightness decrease"; }
+
     // ─── Window Movement and Focus ───
     Mod+Q                               { close-window; }
 


### PR DESCRIPTION
I believe brightness controls should be included in the out of the box CachyOS Niri experience.