### PR TITLE
Change GTK font from Noto Sans to Adwaita Sans

### DIFF
--- a/etc/skel/.config/gtk-3.0/settings.ini
+++ b/etc/skel/.config/gtk-3.0/settings.ini
@@ -1,5 +1,5 @@
 [Settings]
 gtk-application-prefer-dark-theme=true
 gtk-cursor-theme-name=capitaine-cursors
-gtk-font-name=Noto Sans 10
+gtk-font-name=Adwaita Sans 10
 gtk-theme-name=adw-gtk3


### PR DESCRIPTION
Adwaita Sans is default in GNOME apps