### PR TITLE
Change default font from Noto Sans to Adwaita Sans

### DIFF
--- a/etc/skel/.config/gtk-4.0/settings.ini
+++ b/etc/skel/.config/gtk-4.0/settings.ini
@@ -1,3 +1,3 @@
 [Settings]
 gtk-application-prefer-dark-theme=true
-gtk-font-name=Noto Sans, 10
+gtk-font-name=Adwaita Sans, 10


### PR DESCRIPTION
Adwaita Sans is default in GNOME apps