### PR TITLE
window-rules for steam

### DIFF
--- a/etc/skel/.config/niri/cfg/rules.kdl
+++ b/etc/skel/.config/niri/cfg/rules.kdl
@@ -3,6 +3,19 @@
         clip-to-geometry true
     }
 
+     // if you use steam you will probably like these
+    window-rule {
+        match app-id="steam"
+        exclude title=r#"^[Ss]team$"#
+        open-floating true
+    }
+
+    window-rule {
+       match app-id="steam" title=r#"^notificationtoasts_\d+_desktop$"#
+       default-floating-position x=10 y=10 relative-to="bottom-right"
+       open-focused false
+    }
+
     layer-rule {
         match namespace="^noctalia-wallpaper*"
         place-within-backdrop true


### PR DESCRIPTION
So steam's 'Settings' or other pop-ups will be floating. Also steam notifications will show in a more convenient position since steam notifications don't run through the standard notification daemon on niri and show up as floating windows in the center of the screen.