### PR TITLE
Add keybindings for consuming/expelling windows

### DIFF
--- a/etc/skel/.config/niri/cfg/keybinds.kdl
+++ b/etc/skel/.config/niri/cfg/keybinds.kdl
@@ -68,6 +68,9 @@ binds {
     Mod+Shift+CTRL+UP                   { move-column-to-monitor-up; }
     Mod+Shift+CTRL+Down                 { move-column-to-monitor-down; }
 
+    Mod+BracketLeft                     { consume-or-expel-window-left; }
+    Mod+BracketRight                    { consume-or-expel-window-right; }
+
     // ─── Workspace Switching ───
     Mod+WheelScrollDown                 cooldown-ms=150 { focus-workspace-down; }
     Mod+WheelScrollUp                   cooldown-ms=150 { focus-workspace-up; }


### PR DESCRIPTION
(Ported from Niri default keybinds)
The rationale for adding these is 1. To make customizing this action to one's personal preferences easier; and 2. These binds genuinely work fluidly with the current opinionated layout, with `[` and `]` being conveniently located next to each other on the majority of keyboard languages and also nearby the already used `-` and `=` keys.

(For more context on language support: Surprisingly, the languages that support square brackets often place them in more convenient spots than `-` and `=`, with the minus and equals keys being on opposite ends of the keyboard in languages including Czech, Danish, Estonian, and several more.)